### PR TITLE
Fix black text in browser table

### DIFF
--- a/night_mode/stylers.py
+++ b/night_mode/stylers.py
@@ -393,7 +393,7 @@ class BrowserStyler(Styler):
         return f"""
             QTableView
             {{
-                color: {self.config.color_t};
+                selection-color: {self.config.color_t};
                 alternate-background-color: {self.config.color_s};
                 gridline-color: {self.config.color_s};
                 {self.shared.colors}


### PR DESCRIPTION
The browser's table still had black text on the selected item when the table was not focused. This fixed it for me locally (on Windows).