### PR TITLE
Fixed shortcut collision on mac

### DIFF
--- a/night_mode/actions_and_settings.py
+++ b/night_mode/actions_and_settings.py
@@ -251,7 +251,7 @@ class EnableNightMode(Setting, MenuAction):
     """Switch night mode"""
     value = False
     label = '&Enable night mode'
-    shortcut = 'Ctrl+n'
+    shortcut = 'alt+n'
     checkable = True
 
     require = {


### PR DESCRIPTION
On macOS, "ctrl+n" is actually rendered "cmd+n", so it conflicted with the shortcut to change note types within the add card window.