### PR TITLE
Delay loading NM

### DIFF
--- a/night_mode/__init__.py
+++ b/night_mode/__init__.py
@@ -1,3 +1,17 @@
-from .night_mode import NightMode
+from aqt import mw
+from anki.hooks import addHook
 
-night_mode = NightMode()
+
+#addons should selectively load before or after a delay of 666
+NM_RESERVED_DELAY = 666
+
+
+def delayedLoader():
+    from .night_mode import NightMode
+    night_mode = NightMode()
+    night_mode.load()
+
+def onProfileLoaded():
+    mw.progress.timer(NM_RESERVED_DELAY, delayedLoader, False)
+
+addHook('profileLoaded', onProfileLoaded)

--- a/night_mode/night_mode.py
+++ b/night_mode/night_mode.py
@@ -134,7 +134,9 @@ class NightMode:
         )
 
         addHook('unloadProfile', self.save)
-        addHook('profileLoaded', self.load)
+
+        # Disabled, uses delay in __init__.py
+        # addHook('profileLoaded', self.load)
 
         addHook('prepareQA', self.night_class_injection)
 


### PR DESCRIPTION
This resolves the issue that NM was causing for most of my addons due to the loading order (e.g. Blitzkrieg, JS Loader, Kanji Doodle, etc...)

By adding a delay, it ensures NM wraps around Anki last, after other addons.

#53
