### PR TITLE
removed remHook onProfileLoading

### DIFF
--- a/night_mode/__init__.py
+++ b/night_mode/__init__.py
@@ -1,20 +1,27 @@
 from aqt import mw
-from anki.hooks import addHook, remHook
+from anki.hooks import addHook
 
 
 #addons should selectively load before or after a delay of 666
 NM_RESERVED_DELAY = 666
 
+night_mode = None
 
 def delayedLoader():
+    """
+        Delays loading of NM to avoid addon conflicts.
+    """
+    global night_mode
     from .night_mode import NightMode
     night_mode = NightMode()
     night_mode.load()
 
 def onProfileLoaded():
-    remHook("profileLoaded", onProfileLoaded)
-    mw.progress.timer(
-        NM_RESERVED_DELAY, delayedLoader, False
-    )
+    if not night_mode:
+        mw.progress.timer(
+            NM_RESERVED_DELAY, delayedLoader, False
+        )
+    else:
+        night_mode.load()
 
 addHook('profileLoaded', onProfileLoaded)

--- a/night_mode/night_mode.py
+++ b/night_mode/night_mode.py
@@ -137,10 +137,8 @@ class NightMode:
 
         addHook('unloadProfile', self.save)
 
-        # Note: This will not affect the starting profile
-        # due to the delay added in __init__.py.
-        # Only subsequent profiles will be affected.
-        addHook('profileLoaded', self.load)
+        # Disabled, uses delay in __init__.py
+        # addHook('profileLoaded', self.load)
 
         addHook('prepareQA', self.night_class_injection)
 


### PR DESCRIPTION
Replaced creative hooks with standard global variable to check for startup profile.

fixes #103 #104 
